### PR TITLE
chore: Update Docker image references to use Docker Hub

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -1,0 +1,84 @@
+# SteamCMD with Bandwidth Limiting
+
+**Official SteamCMD Debian image with Traffic Control (TC) bandwidth limiting capabilities.**
+
+## What is this?
+
+This image extends the official `steamcmd/steamcmd:debian` image with bandwidth limiting functionality using Linux Traffic Control (TC). It's literally just the official SteamCMD image with added networking tools and a wrapper script that allows you to limit download/upload speeds.
+
+## Key Features
+
+- ✅ **Based on official SteamCMD Debian image** - Same reliability and compatibility
+- ✅ **Traffic Control (TC) bandwidth limiting** - Precise, kernel-level network control  
+- ✅ **Easy to use** - Drop-in replacement for the official image
+- ✅ **No performance overhead** - TC works at the network interface level
+- ✅ **Container-friendly** - Designed specifically for Docker environments
+
+## Quick Start
+
+Simply replace your SteamCMD Docker image with this one and add bandwidth environment variables:
+
+```bash
+# Without bandwidth limiting (works exactly like official image)
+docker run --rm -v /var/lib/steam_cache:/var/lib/steam_cache \
+  astroom/steamcmd-bandwidth:latest \
+  +force_install_dir /var/lib/steam_cache/740 \
+  +login anonymous +app_update 740 validate +quit
+
+# With bandwidth limiting (100 KB/s download limit)
+docker run --rm --privileged \
+  -e BANDWIDTH_ENABLED=true \
+  -e BANDWIDTH_DOWN_RATE=100 \
+  -v /var/lib/steam_cache:/var/lib/steam_cache \
+  astroom/steamcmd-bandwidth:latest \
+  +force_install_dir /var/lib/steam_cache/740 \
+  +login anonymous +app_update 740 validate +quit
+```
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `BANDWIDTH_ENABLED` | Enable bandwidth limiting | `true` |
+| `BANDWIDTH_DOWN_RATE` | Download rate limit in KB/s | `1000` (1 MB/s) |
+| `BANDWIDTH_UP_RATE` | Upload rate limit in KB/s | `500` (512 KB/s) |
+
+## Use Cases
+
+- **Game server hosting** - Control bandwidth usage when caching Steam games
+- **Shared connections** - Limit SteamCMD to prevent it from saturating your network
+- **Cost control** - Prevent unexpected bandwidth charges on metered connections
+- **QoS compliance** - Ensure SteamCMD doesn't interfere with other services
+
+## What's Added to the Base Image
+
+This image adds the following packages to `steamcmd/steamcmd:debian`:
+
+- `iproute2` - Traffic Control (TC) tools
+- `iftop` - Network monitoring
+- `net-tools` - Network utilities  
+- `procps` - Process monitoring
+- `psmisc` - Process utilities
+- `netcat-openbsd` - Network testing
+
+Plus a wrapper script (`steamcmd-bandwidth.sh`) that configures TC before running SteamCMD.
+
+## Requirements
+
+- **Privileged mode required** when using bandwidth limiting: `--privileged`
+- **No special requirements** when bandwidth limiting is disabled
+
+## Python Integration
+
+This image is designed to work with the [steam-game-cacher](https://github.com/astrooom/steam-game-cacher) Python script, but works with any Docker setup.
+
+## Source Code
+
+- **GitHub**: [astrooom/steam-game-cacher](https://github.com/astrooom/steam-game-cacher)
+- **Docker Hub**: [astroom/steamcmd-bandwidth](https://hub.docker.com/r/astroom/steamcmd-bandwidth)
+
+## Tags
+
+- `latest` - Latest stable version with Traffic Control bandwidth limiting
+
+Built on top of the official SteamCMD image - just with bandwidth limiting superpowers! 🚀

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ python3 run.py --app_ids=376030,258550 --install_path=/var/lib/steam_cache
 
 2. Set the environment variable to use the custom image:
 ```bash
-export STEAMCMD_DOCKER_IMAGE=ghcr.io/astrooom/steamcmd-bandwidth:latest
+export STEAMCMD_DOCKER_IMAGE=astroom/steamcmd-bandwidth:latest
 ```
 
 3. Run with bandwidth limiting:
@@ -71,10 +71,16 @@ This project includes a custom Docker image that extends the official SteamCMD i
 ./build-docker.sh
 ```
 
-This creates a Docker image named `ghcr.io/astrooom/steamcmd-bandwidth:latest` that includes:
-- Official SteamCMD base image
-- Traffic Control (TC) bandwidth limiting tools
+This creates a Docker image named `astroom/steamcmd-bandwidth:latest` that includes:
+- Official SteamCMD Debian base image (`steamcmd/steamcmd:debian`)
+- Traffic Control (TC) bandwidth limiting tools (`iproute2`, `iftop`, etc.)
 - Wrapper script for bandwidth-controlled SteamCMD execution
+
+**📦 Pre-built images available on:**
+- **Docker Hub**: `astroom/steamcmd-bandwidth:latest` (recommended)
+- **GitHub Container Registry**: `ghcr.io/astroom/steamcmd-bandwidth:latest`
+
+You can use the pre-built image instead of building locally!
 
 ## Using the Custom Image
 
@@ -82,10 +88,10 @@ Set the `STEAMCMD_DOCKER_IMAGE` environment variable:
 
 ```bash
 # In your shell
-export STEAMCMD_DOCKER_IMAGE=ghcr.io/astrooom/steamcmd-bandwidth:latest
+export STEAMCMD_DOCKER_IMAGE=astroom/steamcmd-bandwidth:latest
 
 # Or in a .env file
-echo "STEAMCMD_DOCKER_IMAGE=ghcr.io/astrooom/steamcmd-bandwidth:latest" >> .env
+echo "STEAMCMD_DOCKER_IMAGE=astroom/steamcmd-bandwidth:latest" >> .env
 ```
 
 ## Bandwidth Limiting Examples

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -6,30 +6,37 @@ set -e
 
 # Configuration
 GITHUB_USERNAME="astrooom"
+DOCKERHUB_USERNAME="astroom"
 IMAGE_NAME="steamcmd-bandwidth"
 IMAGE_TAG="latest"
 LOCAL_IMAGE_NAME="${IMAGE_NAME}:${IMAGE_TAG}"
 GHCR_IMAGE_NAME="ghcr.io/${GITHUB_USERNAME}/${IMAGE_NAME}:${IMAGE_TAG}"
+DOCKERHUB_IMAGE_NAME="${DOCKERHUB_USERNAME}/${IMAGE_NAME}:${IMAGE_TAG}"
 
 echo "Building custom SteamCMD Docker image with bandwidth limiting..."
 echo "Local image: ${LOCAL_IMAGE_NAME}"
 echo "GHCR image: ${GHCR_IMAGE_NAME}"
+echo "Docker Hub image: ${DOCKERHUB_IMAGE_NAME}"
 
-# Build the Docker image
-docker build -t "${LOCAL_IMAGE_NAME}" -t "${GHCR_IMAGE_NAME}" .
+# Build the Docker image with all tags
+docker build -t "${LOCAL_IMAGE_NAME}" -t "${GHCR_IMAGE_NAME}" -t "${DOCKERHUB_IMAGE_NAME}" .
 
 echo ""
 echo "✅ Build completed successfully!"
 echo ""
-echo "📦 To push to GitHub Container Registry:"
+echo "📦 To push to registries:"
+echo "   # GitHub Container Registry:"
 echo "   docker push ${GHCR_IMAGE_NAME}"
 echo ""
-echo "🚀 To use this image with your Steam game cacher:"
-echo "1. Set the environment variable:"
-echo "   export STEAMCMD_DOCKER_IMAGE=${GHCR_IMAGE_NAME}"
+echo "   # Docker Hub:"
+echo "   docker push ${DOCKERHUB_IMAGE_NAME}"
 echo ""
-echo "2. Or create a .env file with:"
-echo "   STEAMCMD_DOCKER_IMAGE=${GHCR_IMAGE_NAME}"
+echo "🚀 To use this image with your Steam game cacher:"
+echo "1. From Docker Hub (recommended for public use):"
+echo "   export STEAMCMD_DOCKER_IMAGE=${DOCKERHUB_IMAGE_NAME}"
+echo ""
+echo "2. From GitHub Container Registry:"
+echo "   export STEAMCMD_DOCKER_IMAGE=${GHCR_IMAGE_NAME}"
 echo ""
 echo "3. Run with bandwidth limiting:"
 echo "   python3 run.py --app_ids=376030 --install_path=/var/lib/steam_cache \\"
@@ -40,6 +47,7 @@ echo "  --bandwidth_enabled=true       Enable bandwidth limiting"
 echo "  --bandwidth_up_rate=500        Upload rate limit in KB/s"
 echo "  --bandwidth_down_rate=1000     Download rate limit in KB/s"
 echo ""
-echo "💡 Note: You must be logged in to GHCR to push:"
-echo "   echo \$GITHUB_TOKEN | docker login ghcr.io -u ${GITHUB_USERNAME} --password-stdin"
+echo "💡 Authentication notes:"
+echo "   # For GHCR: echo \$GITHUB_TOKEN | docker login ghcr.io -u ${GITHUB_USERNAME} --password-stdin"
+echo "   # For Docker Hub: docker login (use your Docker Hub credentials)"
 

--- a/env.example
+++ b/env.example
@@ -1,8 +1,8 @@
 # Steam Game Cacher Configuration
 
 # Docker Image Configuration
-# Use custom Docker image with TC bandwidth limiting from GitHub Container Registry
-STEAMCMD_DOCKER_IMAGE=ghcr.io/astrooom/steamcmd-bandwidth:latest
+# Use custom Docker image with TC bandwidth limiting from Docker Hub
+STEAMCMD_DOCKER_IMAGE=astroom/steamcmd-bandwidth:latest
 
 # Node identification (for Slack notifications)
 NODE_NAME=my-steam-cache-server

--- a/run.py
+++ b/run.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-DOCKER_IMAGE = os.getenv("STEAMCMD_DOCKER_IMAGE", "ghcr.io/astrooom/steamcmd-bandwidth:latest")
+DOCKER_IMAGE = os.getenv("STEAMCMD_DOCKER_IMAGE", "astroom/steamcmd-bandwidth:latest")
 NODE_NAME = os.getenv("NODE_NAME", "unknown")  # Only used for slack notifs.
 slack_channel = os.getenv("SLACK_BOT_CHANNEL")
 slack_token = os.getenv("SLACK_BOT_TOKEN")
@@ -63,8 +63,8 @@ def pull_steamcmd():
     """
     logging.info(f"Checking Docker image: {DOCKER_IMAGE}...")
 
-    # Skip pulling for local images only (GHCR images should be pulled)
-    if DOCKER_IMAGE.startswith('steamcmd-bandwidth') and not DOCKER_IMAGE.startswith('ghcr.io'):
+    # Skip pulling for local images only (public registry images should be pulled)
+    if DOCKER_IMAGE.startswith('steamcmd-bandwidth') and '/' not in DOCKER_IMAGE:
         logging.info(f"Skipping pull for local image: {DOCKER_IMAGE}")
         return
 


### PR DESCRIPTION
- Change default Docker image from GitHub Container Registry to Docker Hub
- Update build script to include Docker Hub image in build process
- Modify example environment file and README to reflect new image source
- Adjust authentication notes for Docker Hub login